### PR TITLE
Allow no selection

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -416,11 +416,7 @@
                         return;
                     }
                     break;
-                case keys.RETURN:
-                    if (that.selectedIndex === -1) {
-                        that.hide();
-                        return;
-                    }
+                case keys.RETURN:                    
                     that.select(that.selectedIndex);
                     break;
                 case keys.UP:
@@ -930,7 +926,12 @@
                 onSelectCallback = that.options.onSelect,
                 suggestion = that.suggestions[index];
 
-            that.currentValue = that.getValue(suggestion.value);
+            if (suggestion) {
+                that.currentValue = that.getValue(suggestion.value);
+            }
+            else {
+                that.currentValue = null;
+            }
 
             if (that.currentValue !== that.el.val() && !that.options.preserveInput) {
                 that.el.val(that.currentValue);


### PR DESCRIPTION
As mentioned [here](https://github.com/devbridge/jQuery-Autocomplete/issues/608#issuecomment-536559933) I'd like to trigger an event when the user presses ENTER without selecting any element from the list.
This PR suggests how this could be possible and how we have currently implemented it.
This would be, of course, a breaking change since the `onSelect` callback is now responsible for checking whether there is a selection or not.
```js
onSelect(suggestion) {
  if (suggestion) {
    // do something with selection
  } else {
    // do something with no selection
  }
}
```